### PR TITLE
Updated select values for Experience level on AddProject.tsx form

### DIFF
--- a/src/pages/AddProject.tsx
+++ b/src/pages/AddProject.tsx
@@ -253,9 +253,10 @@ class AddProject extends React.Component<RouteComponentProps, FormState> {
             onBlur={this.handleChange}
             className={classNames({ "field-error": errors.experienceLevel.length > 0 })}>
             <option value="">Select your experience level</option>
-            <option value="0">Learner (0+ years of experience)</option>
-            <option value="1">Beginner (1+ years of experience)</option>
-            <option value="2">Experienced (3+ years of experience)</option>
+            <option value="0">0-1 years</option>
+            <option value="1">1-3 years</option>
+            <option value="2">3-5 years</option>
+            <option value="3">5+ years</option>
           </select>
           {errors.experienceLevel.length > 0 && <span className="error">{errors.experienceLevel}</span>}
 


### PR DESCRIPTION
Closes #98 Change select values for experience level.

I changed the display text for the options in the experience level select field and added an additional option with value of "3" for 5+ years. I tested the form several times to ensure that the data updated the database. I also checked the FormState type to ensure there was consistency in the value data types.

Screenshot:
![Screen Shot 2020-10-01 at 2 35 06 PM](https://user-images.githubusercontent.com/34215359/94850163-84368080-03f4-11eb-9454-16a5a5e51ec1.png)

@nurmerey: I believe this is ready for review but I am unable to assign a reviewer.