### PR TITLE
Add Description Headers to Project Card

### DIFF
--- a/src/components/ProjectCard.tsx
+++ b/src/components/ProjectCard.tsx
@@ -84,15 +84,16 @@ const ProjectCard: FC<Props> = ({ data, loginLink }) => {
         <p>{project.description}</p>
       </div>
 
-      <div className="card-lead">
-        <h3>Project Lead: {project.lead.name}</h3>
-        <p>{project.lead.position}</p>
-        <p>{experienceLevel}</p>
-      </div>
-
       <div className="card-looking-for">
         <p className="card-looking-for-label">Looking For:</p>
         <p>{project.looking_for}</p>
+      </div>
+
+      <div className="card-lead">
+        <p className="card-lead-label">Project Lead:</p>
+        <p>{project.lead.name}</p>
+        <p>{project.lead.position}</p>
+        <p>{experienceLevel}</p>
       </div>
 
       <div className="card-contributors">

--- a/src/components/ProjectCard.tsx
+++ b/src/components/ProjectCard.tsx
@@ -79,13 +79,16 @@ const ProjectCard: FC<Props> = ({ data, loginLink }) => {
     <article className="card-wrapper">
       <h2>{project.name}</h2>
 
+      <div className="card-description">
+        <p className="card-description-label">Project Description:</p>
+        <p>{project.description}</p>
+      </div>
+
       <div className="card-lead">
         <h3>Project Lead: {project.lead.name}</h3>
         <p>{project.lead.position}</p>
         <p>{experienceLevel}</p>
       </div>
-
-      <p className="card-description">{project.description}</p>
 
       <div className="card-looking-for">
         <p className="card-looking-for-label">Looking For:</p>

--- a/src/style/components/ProjectCard.css
+++ b/src/style/components/ProjectCard.css
@@ -59,11 +59,16 @@
 }
 
 .card-looking-for {
-  min-height: 110px;
+  min-height: 130px;
+}
+
+.card-lead {
+  min-height: 120px;
 }
 
 .card-description-label,
 .card-looking-for-label,
+.card-lead-label,
 .card-contributor-label,
 .card-tech-stack-label {
   text-transform: uppercase;

--- a/src/style/components/ProjectCard.css
+++ b/src/style/components/ProjectCard.css
@@ -55,13 +55,14 @@
 }
 
 .card-description {
-  min-height: 150px;
+  min-height: 100px;
 }
 
 .card-looking-for {
   min-height: 110px;
 }
 
+.card-description-label,
 .card-looking-for-label,
 .card-contributor-label,
 .card-tech-stack-label {


### PR DESCRIPTION
Closes https://github.com/shescoding/projects-platform-frontend/issues/91

I made the description and project lead sections the same format as the others. One note is that the `Looking For` section has a high minimum height because one project (Presently) on the website has a longer value. That project should cut down on that section as there's information that doesn't belong there, then that height can be reduced.

Finished result:
![Screen Shot 2020-10-01 at 2 18 33 PM](https://user-images.githubusercontent.com/16989366/94853533-23f20f80-03f1-11eb-9039-c09b9be4a1ae.png)
