### PR TITLE
added delete project api endpoint

### DIFF
--- a/server/routes/github_oauth.js
+++ b/server/routes/github_oauth.js
@@ -351,6 +351,23 @@ async function addNewProject(auth_token, position, experience_lvl, new_project) 
     });
 }
 
+async function deleteProject(id) {
+  let SQL = `DELETE FROM projects WHERE id=${id};`;
+  await client.query(SQL)
+    .then(async (res) => {
+      return res;
+    })
+    .catch(err => {
+      throw err;
+    });
+};
+
+router.post("/projects/:id/delete", async (req,res) => {
+  const response = await deleteProject(req.params.id);
+  return res.send({ "result": `${response}` });
+});
+
+
 router.post("/projects/add_project/", async (req, res) => {
   const github_url = req.body["github_url"];
   const repo_details = github_url.split(

--- a/server/routes/github_oauth.js
+++ b/server/routes/github_oauth.js
@@ -363,6 +363,10 @@ async function deleteProject(id) {
 };
 
 router.post("/projects/:id/delete", async (req,res) => {
+  const auth_token = getToken(req.headers.authorization);
+  if (auth_token === null) {
+    return res.sendStatus(401);
+  }
   const response = await deleteProject(req.params.id);
   return res.send({ "result": `${response}` });
 });


### PR DESCRIPTION
This change addressed issue #103: Create API endpoint that would delete a project.

To use:
- POST http://127.0.0.1:5000/projects/<project_id>/delete

Contributors:
@natalie-poulson
@madelynnelson 
@littlemisslilycane 



