### PR TITLE
Rename the 'Sign in with Github' button below the 'Open Source Collab' section to "Join Us"

### DIFF
--- a/src/components/PlatformSummary.tsx
+++ b/src/components/PlatformSummary.tsx
@@ -11,7 +11,7 @@ const PlatformSummary = (props: ProjectSummaryProps) => {
     if (!!token) {
       return (<a className="button-link" href="/#/projects">See All Projects</a>)} 
     else {
-      return (<button onClick={props.login}>Sign In With GitHub</button>)
+      return (<button onClick={props.login}>Join Us</button>)
     }
 
   }


### PR DESCRIPTION
Fix for https://github.com/shescoding/projects-platform-frontend/issues/108 